### PR TITLE
[GITHUB-6] Added checkconfig templates for php 5.5 and 5.6.

### DIFF
--- a/tasks/build.yml
+++ b/tasks/build.yml
@@ -4,7 +4,7 @@
   become: yes
   apt_repository:
     repo: ppa:ondrej/php
-  when: php.version == "php7.0"
+  when: ((php.version == "php5.5") or (php.version == "php5.6") or (php.version == "php7.0"))
 
 - name: Install PHP
   become: yes

--- a/templates/php5.5-fpm-checkconfig.j2
+++ b/templates/php5.5-fpm-checkconfig.j2
@@ -1,0 +1,14 @@
+#!/bin/sh
+
+##
+# {{ ansible_managed }}
+#
+
+set -e
+errors=$(/usr/sbin/php-fpm5.5 --fpm-config /home/{{ php.fpm.user }}/etc/php-fpm.conf -t 2>&1 | grep "\[ERROR\]" || true);
+if [ -n "$errors" ]; then
+	echo "Please fix your configuration file..."
+	echo $errors
+	exit 1
+fi
+exit 0

--- a/templates/php5.6-fpm-checkconfig.j2
+++ b/templates/php5.6-fpm-checkconfig.j2
@@ -1,0 +1,14 @@
+#!/bin/sh
+
+##
+# {{ ansible_managed }}
+#
+
+set -e
+errors=$(/usr/sbin/php-fpm5.6 --fpm-config /home/{{ php.fpm.user }}/etc/php-fpm.conf -t 2>&1 | grep "\[ERROR\]" || true);
+if [ -n "$errors" ]; then
+	echo "Please fix your configuration file..."
+	echo $errors
+	exit 1
+fi
+exit 0


### PR DESCRIPTION
Currently this role only supports php7 and the version of php5 that ships with the OS. The ppa:ondrej/php repo now installs php 5.5, 5.6, 7.0 & 7.1 in the /etc/php directory. There are no longer dedicated repos for each of those versions. They are now merged into one. Due to the way this role is currently configured it is not possible to install versions 5.5 or 5.6. Only the native version that ships with the OS. Modifications need to be made to allow the role to be more flexible.

@lobsterdore 