### PR TITLE
[GITHUB-15] Moves ulimit increase to init script

### DIFF
--- a/tasks/fpm.yml
+++ b/tasks/fpm.yml
@@ -27,15 +27,6 @@
     value: "{{ php.fpm.rlimit }}"
   when: php.fpm.rlimit
 
-- name: Configure pam for nofile limit raise
-  become: yes
-  lineinfile:
-    dest: "/etc/pam.d/{{ item }}"
-    line: "session required pam_limits.so"
-  with_items:
-    - common-session
-    - common-session-noninteractive
-
 - name: Create PHP ini for FPM
   become: yes
   become_user: "{{ php.fpm.user }}"

--- a/templates/initd.j2
+++ b/templates/initd.j2
@@ -26,6 +26,16 @@ PIDFILE=/home/{{ php.fpm.user }}/run/{{ php.version }}-fpm.pid
 TIMEOUT=30
 SCRIPTNAME=/etc/init.d/$NAME
 
+{% if php.fpm.rlimit %}
+# Maximum number of open files
+MAX_OPEN_FILES={{ php.fpm.rlimit }}
+{% endif %}
+
+if [ `id -u` -ne 0 ]; then
+	echo "You need root privileges to run this script"
+	exit 1
+fi
+
 # Exit if the package is not installed
 [ -x "$DAEMON" ] || exit 0
 
@@ -58,6 +68,9 @@ do_check()
 #
 do_start()
 {
+	if [ -n "$MAX_OPEN_FILES" ]; then
+		ulimit -n $MAX_OPEN_FILES
+	fi
 	# Return
 	#   0 if daemon has been started
 	#   1 if daemon was already running


### PR DESCRIPTION
Current method does not work, this nicks the method used by
ElasticSearch where the init script raise the ulimit, had to
limit usage of the script to root to ensure that the raise can
take place.